### PR TITLE
Update to support x-forwarded-* header with multiple values

### DIFF
--- a/build/bundle.js
+++ b/build/bundle.js
@@ -1136,7 +1136,7 @@ module.exports =
 	    }
 	    routingInfo.appPath = '/' + segments.join('/');
 	    routingInfo.baseUrl = [
-	        req.headers['x-forwarded-proto'] || 'https',
+	        req.headers['x-forwarded-proto'] ? req.headers['x-forwarded-proto'].split(',')[0].trim() : 'https',
 	        '://',
 	        req.headers.host,
 	        routingInfo.basePath


### PR DESCRIPTION
Hi, I'm Randall with Auth0.

With some upcoming changes in the Auth0 webtasks infrastructure, the `x-forwarded-*` headers will soon have multiple values (comma-separated). This is valid according to the specification.  Please accept this PR so as to update the extension to support multiple values in the `x-forwarded-*` headers. 

Thanks!